### PR TITLE
Add necessary libraries for pg_dump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM postgres:16-alpine as build
+FROM --platform=linux/amd64 postgres:16-alpine as build
 
 RUN apk update && apk add --no-cache \
     libffi-dev \
     gcc \
+    openldap \
+    musl \
     musl-dev \
     git \
     python3=~3.12 \
@@ -28,8 +30,12 @@ RUN cp \
     /usr/local/bin/psql \
     /usr/local/lib/libpq.so.5 \
     /usr/local/lib/libpq.so.5.16 \
+    /usr/lib/libldap.so.2 \
+    /lib/libc.musl-x86_64.so.1 \
     ./bin
- 
+
+RUN chmod +x bin/libldap.so.2
+
 COPY requirements.txt .
 RUN pip install -r requirements.txt --target .
 RUN find . -name "*.pyc" -delete

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 postgres:16-alpine as build
 RUN apk update && apk add --no-cache \
     libffi-dev \
     gcc \
-    openldap \
+    openldap-dev \
     musl-dev \
     git \
     python3=~3.12 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apk update && apk add --no-cache \
     libffi-dev \
     gcc \
     openldap \
-    musl \
     musl-dev \
     git \
     python3=~3.12 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN cp \
     /usr/local/lib/libpq.so.5.16 \
     /usr/lib/libldap.so.2 \
     /lib/libc.musl-x86_64.so.1 \
+    /usr/lib/libedit.so.0 \
     ./bin
 
 RUN chmod +x bin/libldap.so.2


### PR DESCRIPTION
**ClickUp Ticket:** [8688zghwn](https://app.clickup.com/t/8688zghwn)

Follow up to: https://github.com/Pennsieve/discover-pgdump-lambda/pull/1

Adds missing C libraries to link when running `pg_dump` because they do not come automatically with the AWS python3.12 runtime environment.

Output below is the seeing the libraries being referenced from the local bin folder and successfully fulfilling `pg_dump` (and `psql`) requirements.

```
8c96cc9c6dba:/lambda# ldd bin/pg_dump
        /lib/ld-musl-x86_64.so.1 (0x7ffffff5d000)
        libpq.so.5 => /usr/local/lib/libpq.so.5 (0x7fffff69b000)
        libzstd.so.1 => /usr/lib/libzstd.so.1 (0x7fffff5ea000)
        liblz4.so.1 => /usr/lib/liblz4.so.1 (0x7fffff5c8000)
        libz.so.1 => /lib/libz.so.1 (0x7fffff5ae000)
        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7ffffff5d000)
        libssl.so.3 => /lib/libssl.so.3 (0x7fffff4eb000)
        libcrypto.so.3 => /lib/libcrypto.so.3 (0x7fffff0a3000)
        libgssapi_krb5.so.2 => /usr/lib/libgssapi_krb5.so.2 (0x7fffff060000)
        libldap.so.2 => /usr/lib/libldap.so.2 (0x7fffff00f000)
        libkrb5.so.3 => /usr/lib/libkrb5.so.3 (0x7ffffef60000)
        libk5crypto.so.3 => /usr/lib/libk5crypto.so.3 (0x7ffffef35000)
        libcom_err.so.2 => /lib/libcom_err.so.2 (0x7ffffef2f000)
        libkrb5support.so.0 => /usr/lib/libkrb5support.so.0 (0x7ffffef24000)
        liblber.so.2 => /usr/lib/liblber.so.2 (0x7ffffef16000)
        libsasl2.so.3 => /usr/lib/libsasl2.so.3 (0x7ffffeefc000)
        libkeyutils.so.1 => /usr/lib/libkeyutils.so.1 (0x7ffffeef6000)
8c96cc9c6dba:/lambda# ldd bin/psql
        /lib/ld-musl-x86_64.so.1 (0x7ffffff5d000)
        libpq.so.5 => /usr/local/lib/libpq.so.5 (0x7fffff64a000)
        libpq.so.5 => bin/libpq.so.5 (0x7fffff64a000)
        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7ffffff5d000)
        libssl.so.3 => /lib/libssl.so.3 (0x7fffff558000)
        libcrypto.so.3 => /lib/libcrypto.so.3 (0x7fffff110000)
        libgssapi_krb5.so.2 => /usr/lib/libgssapi_krb5.so.2 (0x7fffff0cd000)
        libldap.so.2 => /usr/lib/libldap.so.2 (0x7fffff07c000)
        libncursesw.so.6 => /usr/lib/libncursesw.so.6 (0x7fffff028000)
        libkrb5.so.3 => /usr/lib/libkrb5.so.3 (0x7ffffef79000)
        libk5crypto.so.3 => /usr/lib/libk5crypto.so.3 (0x7ffffef4e000)
        libcom_err.so.2 => /lib/libcom_err.so.2 (0x7ffffef48000)
        libkrb5support.so.0 => /usr/lib/libkrb5support.so.0 (0x7ffffef3d000)
        liblber.so.2 => /usr/lib/liblber.so.2 (0x7ffffef2f000)
        libsasl2.so.3 => /usr/lib/libsasl2.so.3 (0x7ffffef15000)
        libkeyutils.so.1 => /usr/lib/libkeyutils.so.1 (0x7ffffef0f000)
```