### PR TITLE
8688zghwn use amazon python3.11 base image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,10 +13,10 @@ node('executor') {
     env.ENVIRONMENT = "local"
 
     try {
-        // stage("Run Tests") {
-        //     sh "make pull"
-        //     sh "make test"
-        // }
+        stage("Run Tests") {
+            sh "make pull"
+            sh "make test"
+        }
 
         if(isMain) {
             stage ('Build and Push') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - emptydb
       - pennsievedb
     platform: linux/amd64
+    entrypoint: []
     environment:
       ENVIRONMENT: local
       SERVICE_NAME: discover
@@ -17,6 +18,7 @@ services:
       AWS_ACCESS_KEY_ID: xxxx
       AWS_SECRET_ACCESS_KEY: yyyy
       AWS_DEFAULT_REGION: 'us-east-1'
+      PGSSLMODE: 'allow'
 
   pennsievedb:
     hostname: pennsievedb

--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ def lambda_handler(event, context):
         pg_database = os.environ['POSTGRES_DATABASE']
         pg_port     = os.environ['POSTGRES_PORT']
         pg_host     = os.environ['POSTGRES_HOST']
+        pg_sslmode  = os.getenv('PGSSLMODE', 'require')
         s3_bucket   = os.environ['S3_BUCKET']
 
         log.info(f"POSTGRES_HOST: {pg_host}")
@@ -117,6 +118,7 @@ def lambda_handler(event, context):
             '--section', 'data',
         ], env={
             'PGPASSWORD': pg_password,
+            'PGSSLMODE': pg_sslmode,
             'LD_LIBRARY_PATH': PG_PATH
         },
            stdout=subprocess.PIPE,

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,7 +15,7 @@ variable "service_name" {}
 variable "tier" {}
 
 variable "runtime" {
-  default = "python3.12"
+  default = "python3.11"
 }
 
 variable "bucket" {


### PR DESCRIPTION
## Motivation
**ClickUp Ticket:** [8688zghwn](https://app.clickup.com/t/8688zghwn)

Follow up to: https://github.com/Pennsieve/discover-pgdump-lambda/pull/1, https://github.com/Pennsieve/discover-pgdump-lambda/pull/2, and https://github.com/Pennsieve/discover-pgdump-lambda/pull/3 

The original upgrade lambda zip didn't work because the `pg_dump` build was built for Alpine (which uses musl) and not Amazon Linux (which uses glibc). Unfortunatelly Amazon Linux OS doesn't have a pre-built Postgres16 binary so we need to build it manually. See: https://github.com/amazonlinux/amazon-linux-2023/issues/516.

Used the `public.ecr.aws/lambda/python:3.11` to most closely mimic the runtime environment of the Lambda function. Which meant I needed to downgrade some of the previous build upgrades from 3.12 to 3.11.

Built with SSL because SSL is required from our RDS configuration.

## Testing
Built and published the Lambda zip locally and ran the function through the AWS console until it finally succeeded.

